### PR TITLE
Make user wallet persistent

### DIFF
--- a/src/components/AccountDetails/index.tsx
+++ b/src/components/AccountDetails/index.tsx
@@ -11,7 +11,7 @@ import Transaction from './Transaction'
 
 import { SUPPORTED_WALLETS } from '../../constants'
 import { ReactComponent as Close } from '../../assets/images/x.svg'
-import { getExploreLink } from '../../utils'
+import { getExploreLink, userAccount } from '../../utils'
 import { injected } from '../../connectors'
 import Identicon from '../Identicon'
 
@@ -253,7 +253,7 @@ export default function AccountDetails({
   }
 
   function getStatusIcon() {
-    if (connector === injected) {
+    if (account) {
       return (
         <IconWrapper size={16}>
           <Identicon /> {formatConnectorName()}
@@ -283,11 +283,9 @@ export default function AccountDetails({
               <AccountGroupingRow>
                 {getStatusIcon()}
                 <div>
-                  {connector !== injected && (
+                  {account && (
                     <WalletAction
-                      onClick={() => {
-                        ;(connector as any).close()
-                      }}
+                      onClick={userAccount.remove}
                     >
                       Disconnect
                     </WalletAction>

--- a/src/connectors/InjectedConnector/index.ts
+++ b/src/connectors/InjectedConnector/index.ts
@@ -2,8 +2,10 @@ import Connex from '@vechain/connex'
 import { AbstractConnectorArguments, ConnectorUpdate } from '../types'
 import { AbstractConnector } from '../AbstractConnector'
 import warning from 'tiny-warning'
+import { userAccount } from '../../utils'
 
 const connex = new Connex({ node: 'https://mainnet.veblocks.net' })
+// const connex = new Connex({ node: 'https://testnet.veblocks.net', network: 'test' })
 
 const msg = {
   purpose: 'identification',
@@ -68,6 +70,7 @@ export class InjectedConnector extends AbstractConnector {
     try {
       const { annex } = await sign.request()
       account = annex.signer
+      userAccount.set(account)
     } catch (error) {
       if ((error as any).code === 4001) {
         throw new UserRejectedRequestError()

--- a/src/context/manager.ts
+++ b/src/context/manager.ts
@@ -2,6 +2,7 @@ import { useReducer, useEffect, useCallback, useRef } from 'react'
 import { ConnectorUpdate, ConnectorEvent } from '../connectors/types'
 import { AbstractConnector } from '../connectors/AbstractConnector'
 import warning from 'tiny-warning'
+import { userAccount } from '../utils'
 
 import { Web3ReactManagerReturn } from './types'
 import { normalizeChainId, normalizeAccount } from './normalizers'
@@ -107,9 +108,8 @@ async function augmentConnectorUpdate(
   if (!!connector.supportedChainIds && !connector.supportedChainIds.includes(chainId)) {
     throw new UnsupportedChainIdError(chainId, connector.supportedChainIds)
   }
-  const account = _account === null ? _account : normalizeAccount(_account)
 
-  return { provider, chainId, account }
+  return { provider, chainId, account: userAccount.get(_account) }
 }
 
 export function useWeb3ReactManager(): Web3ReactManagerReturn {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -11,6 +11,7 @@ import { ROUTER_ADDRESS } from '../constants'
 
 import ERC20_ABI from '../constants/abis/erc20.json'
 import { ChainId, JSBI, Percent, TokenAmount } from 'vexchange-sdk'
+import { normalizeAccount } from '../context/normalizers'
 
 // returns the checksummed address if the address is valid, otherwise returns false
 export function isAddress(value: any): string | false {
@@ -29,6 +30,20 @@ export enum ERROR_CODES {
 const EXPLORE_PREFIXES: { [chainId in ChainId]: string } = {
   1: 'explore.',
   3: 'explore-testnet.'
+}
+
+export const userAccount = {
+  get: (account: string) => {
+    const savedAccount = localStorage.getItem('wallet')
+    return savedAccount ? normalizeAccount(savedAccount) : account
+  },
+  set: (account: string) => {
+    localStorage.setItem('wallet', account)
+  },
+  remove: () => {
+    localStorage.removeItem('wallet')
+    window.location.href = '/'
+  }
 }
 
 export function getExploreLink(chainId: ChainId, data: string, type: 'transaction' | 'address'): string {


### PR DESCRIPTION
Problem: When the user connects the wallet and refreshes the page, the app loses track of the user's wallet, making the user reconnecting the wallet every time
Fix: When the user enters the wallet address the app remembers the wallet by using localStorage

Ticket: https://trello.com/c/OgZMMbcr/77-fix-misc-errors

Approach browser compatibility: https://caniuse.com/?search=localstorage