### PR TITLE
Add support for vet.domains

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -7,6 +7,7 @@ import { isMobile } from 'react-device-detect'
 
 import styled, { css } from 'styled-components'
 import { useTokenBalanceTreatingWETHasETH } from '../../state/wallet/hooks'
+import { getName } from '../../utils/nameutils'
 
 import Row from '../Row'
 import Menu from '../Menu'
@@ -52,7 +53,7 @@ const HeaderElement = styled.div`
   align-items: center;
 `
 
-const VexIcon = styled(HistoryLink)<{ to: string }>`
+const VexIcon = styled(HistoryLink) <{ to: string }>`
   transition: transform 0.3s ease;
   :hover {
     transform: scale(1.1);
@@ -129,7 +130,7 @@ const NetworkCard = styled(YellowCard)`
   padding: 8px 12px;
 `
 
-const MigrateBanner = styled(AutoColumn)<{ isDark?: boolean }>`
+const MigrateBanner = styled(AutoColumn) <{ isDark?: boolean }>`
   width: 100%;
   padding: 12px 0;
   display: flex;
@@ -196,6 +197,7 @@ export default function Header() {
   const { account, chainId, active, library } = useWeb3React()
   const [darkMode, toggleDarkMode] = useDarkModeManager()
   const [userVexBalance, setUserVexBalance] = useState(0)
+  const [username, setUsername] = useState('')
 
   const userEthBalance = useTokenBalanceTreatingWETHasETH(account, DUMMY_VET[chainId])
   const [isDark] = useDarkModeManager()
@@ -211,6 +213,17 @@ export default function Header() {
       getUserVexBalance()
     }
   }, [account, userVexBalance, chainId, library])
+
+  useEffect(() => {
+    const getUsername = async () => {
+      const username = await getName(account, library)
+      setUsername(username)
+    }
+
+    if (account) {
+      getUsername()
+    }
+  }, [account, chainId, library])
 
   return (
     <HeaderFrame>
@@ -255,7 +268,7 @@ export default function Header() {
                 </Text>
               </>
             ) : null}
-            <Web3Status account={account} active={active} />
+            <Web3Status account={account} name={username} active={active} />
           </AccountElement>
           <ButtonSecondary
             isDark={isDark}

--- a/src/components/Web3Status/index.tsx
+++ b/src/components/Web3Status/index.tsx
@@ -160,7 +160,7 @@ function recentTransactionsOnly(a: TransactionDetails) {
   return new Date().getTime() - a.addedTime < 86_400_000
 }
 
-export default function Web3Status({ account, active }) {
+export default function Web3Status({ account, name, active }) {
   const { t } = useTranslation()
   const { error } = useWeb3React()
   const contextNetwork = useWeb3React(NetworkContextName)
@@ -188,7 +188,7 @@ export default function Web3Status({ account, active }) {
               <Text>{pending?.length} Pending</Text> <SpinnerWrapper src={LightCircle} alt="loader" />
             </RowBetween>
           ) : (
-            <Text>{shortenAddress(account)}</Text>
+            <Text>{name || shortenAddress(account)}</Text>
           )}
           {!hasPendingTransactions && <Identicon />}
         </Web3StatusConnected>

--- a/src/utils/nameutils.ts
+++ b/src/utils/nameutils.ts
@@ -1,0 +1,92 @@
+import namehash from 'eth-ens-namehash'
+import { isAddress } from './'
+import { AddressZero } from '@ethersproject/constants'
+
+const VET_REGISTRY_ADDRESS = '0xa9231da8BF8D10e2df3f6E03Dd5449caD600129b'
+
+const ABI = {
+  resolver: {
+    inputs: [{ internalType: 'bytes32', name: 'node', type: 'bytes32' }],
+    name: 'resolver',
+    outputs: [{ internalType: 'address', name: 'resolverAddress', type: 'address' }],
+    stateMutability: 'view',
+    type: 'function'
+  },
+
+  addr: {
+    inputs: [{ internalType: 'bytes32', name: 'node', type: 'bytes32' }],
+    name: 'addr',
+    outputs: [{ internalType: 'address payable', name: 'address', type: 'address' }],
+    stateMutability: 'view',
+    type: 'function'
+  },
+
+  name: {
+    inputs: [{ internalType: 'bytes32', name: 'node', type: 'bytes32' }],
+    name: 'name',
+    outputs: [{ internalType: 'string', name: 'name', type: 'string' }],
+    stateMutability: 'view',
+    type: 'function'
+  }
+}
+
+export async function getRecord(name: string, connex: Connex): Promise<string> {
+  const node = namehash.hash(name)
+
+  const {
+    decoded: { resolverAddress },
+    reverted: noResolver
+  } = await connex.thor
+    .account(VET_REGISTRY_ADDRESS)
+    .method(ABI.resolver)
+    .call(node)
+  if (noResolver || resolverAddress === AddressZero) {
+    throw new Error('Resolver not configurd')
+  }
+
+  const {
+    decoded: { address },
+    reverted: noLookup
+  } = await connex.thor
+    .account(resolverAddress)
+    .method(ABI.addr)
+    .call(node)
+  if (noLookup) {
+    throw new Error('Resolver returned no address')
+  }
+
+  return address
+}
+
+export async function getName(address: string, connex: Connex): Promise<string> {
+  const reverseLookup = `${address.slice(2).toLowerCase()}.addr.reverse`
+  const node = namehash.hash(reverseLookup)
+
+  const {
+    decoded: { resolverAddress },
+    reverted: noResolver
+  } = await connex.thor
+    .account(VET_REGISTRY_ADDRESS)
+    .method(ABI.resolver)
+    .call(node)
+  if (noResolver || resolverAddress === AddressZero) {
+    return ''
+  }
+
+  const {
+    decoded: { name },
+    reverted: noLookup
+  } = await connex.thor
+    .account(resolverAddress)
+    .method(ABI.name)
+    .call(node)
+  if (noLookup) {
+    return ''
+  }
+
+  return name
+}
+
+export async function getAddress(addressOrName: string, connex: Connex): Promise<string> {
+  return isAddress(addressOrName) ? addressOrName : await getRecord(addressOrName, connex)
+}


### PR DESCRIPTION
This Pull Requests adds support for https://vet.domains

1. Names are displayed on the connection indicator
2. Sending Dialog: Accept names as input and resolve them to their address record

The name handling is isolated in `utils/nameutils.ts`

![Bildschirmfoto 2024-02-01 um 13 32 59](https://github.com/vexchange/vexchange-interface/assets/407503/108a3f42-3a3d-4d9b-85d9-0e683230b6c9)

If there are more locations that would require name handling, please let me know with a link & file reference.

Thank you in advance 🙏
